### PR TITLE
Updated for latest core++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,15 +1,7 @@
-add_library(spindle INTERFACE)
+add_library(picohal INTERFACE)
 
-target_sources(spindle INTERFACE
- ${CMAKE_CURRENT_LIST_DIR}/modbus.c
- ${CMAKE_CURRENT_LIST_DIR}/select.c
- ${CMAKE_CURRENT_LIST_DIR}/vfd/spindle.c
- ${CMAKE_CURRENT_LIST_DIR}/vfd/huanyang.c
- ${CMAKE_CURRENT_LIST_DIR}/vfd/huanyang2.c
- ${CMAKE_CURRENT_LIST_DIR}/vfd/h100.c
- ${CMAKE_CURRENT_LIST_DIR}/vfd/modvfd.c
- ${CMAKE_CURRENT_LIST_DIR}/vfd/gs20.c
- ${CMAKE_CURRENT_LIST_DIR}/vfd/yl620.c
+target_sources(picohal INTERFACE
+ ${CMAKE_CURRENT_LIST_DIR}/picohal.c
 )
 
-target_include_directories(spindle INTERFACE ${CMAKE_CURRENT_LIST_DIR})
+target_include_directories(picohal INTERFACE ${CMAKE_CURRENT_LIST_DIR})

--- a/picohal.h
+++ b/picohal.h
@@ -28,14 +28,15 @@
 #include "../../grbl/protocol.h"
 #include "../../grbl/state_machine.h"
 #include "../../grbl/report.h"
+#include "../../grbl/modbus.h"
 #else
 #include "grbl/hal.h"
 #include "grbl/protocol.h"
 #include "grbl/state_machine.h"
 #include "grbl/report.h"
+#include "grbl/modbus.h"
 #endif
 
-#include "spindle/modbus.h"
 
 #define RETRY_DELAY         250
 #define POLLING_INTERVAL    100


### PR DESCRIPTION
The modbus.h file has been moved to the core. CMakeLists.txt fixed to allow compilation for RP2040 Web Builder builds with PicoHAL selected in the 3rd party plugins tab.